### PR TITLE
#1 - Inline style or CSS classes

### DIFF
--- a/src/Markdig.SyntaxHighlighting.Core.Tests/Example/CodeSample.cs
+++ b/src/Markdig.SyntaxHighlighting.Core.Tests/Example/CodeSample.cs
@@ -26,5 +26,47 @@ namespace Markdig.SyntaxHighlighting.Core.Tests.Example {
             File.WriteAllText(Path.Combine(folder, "actual.html"), actualHtml);
             Assert.Equal(expectedHtml, actualHtml);
         }
+
+        [Fact]
+        public void CodeSampleWorksWithoutClasses() {
+            var appPath = Environment.CurrentDirectory;
+            var folder = Path.Combine(appPath, "Example");
+            var inputMarkdown = Path.Combine(folder, "README.md");
+            var referenceFile = Path.Combine(folder, "expected.html");
+            var expectedHtml = File.ReadAllText(referenceFile);
+            var markdown = File.ReadAllText(inputMarkdown);
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .UseSyntaxHighlighting(false)
+                .Build();
+            var html = Markdown.ToHtml(markdown, pipeline);
+            var actualHtml = File.ReadAllText(Path.Combine(folder, "_template.html"))
+                .Replace("{{{this}}}", html);
+            actualHtml = actualHtml.Replace("\r\n", "\n").Replace("\n", "\r\n");
+            expectedHtml = expectedHtml.Replace("\r\n", "\n").Replace("\n", "\r\n");
+            File.WriteAllText(Path.Combine(folder, "actual.html"), actualHtml);
+            Assert.Equal(expectedHtml, actualHtml);
+        }
+
+        [Fact]
+        public void CodeSampleWorksWithlasses() {
+            var appPath = Environment.CurrentDirectory;
+            var folder = Path.Combine(appPath, "Example");
+            var inputMarkdown = Path.Combine(folder, "README.md");
+            var referenceFile = Path.Combine(folder, "expected-classes.html");
+            var expectedHtml = File.ReadAllText(referenceFile);
+            var markdown = File.ReadAllText(inputMarkdown);
+            var pipeline = new MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .UseSyntaxHighlighting(true)
+                .Build();
+            var html = Markdown.ToHtml(markdown, pipeline);
+            var actualHtml = File.ReadAllText(Path.Combine(folder, "_template.html"))
+                .Replace("{{{this}}}", html);
+            actualHtml = actualHtml.Replace("\r\n", "\n").Replace("\n", "\r\n");
+            expectedHtml = expectedHtml.Replace("\r\n", "\n").Replace("\n", "\r\n");
+            File.WriteAllText(Path.Combine(folder, "actual.html"), actualHtml);
+            Assert.Equal(expectedHtml, actualHtml);
+        }
     }
 }

--- a/src/Markdig.SyntaxHighlighting.Core.Tests/Example/expected-classes.html
+++ b/src/Markdig.SyntaxHighlighting.Core.Tests/Example/expected-classes.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="gfm.css">
+  </head>
+  <body class="markdown-body">
+    <p>This is before the table</p>
+<table>
+<thead>
+<tr>
+<th>Heading 1</th>
+<th>Heading 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Row 1</td>
+<td>Cell 2</td>
+</tr>
+</tbody>
+</table>
+<p>This is after the table</p>
+<div class="lang-csharp editor-colors"><div class="csharp"><pre>
+<span class="comment">// &#169;2015 Amido Limited (https://www.amido.com), Licensed under the terms of the Apache 2.0 Licence (http://www.apache.org/licenses/LICENSE-2.0)</span>
+
+<span class="keyword">namespace</span> Amido.VersionDashboard.Web.Domain {
+    <span class="keyword">public</span> <span class="keyword">interface</span> IConfigProvider {
+        <span class="keyword">string</span> GetSetting(<span class="keyword">string</span> appSetting);
+    }
+}
+</pre></div>
+</div>
+
+  </body>
+</html>

--- a/src/Markdig.SyntaxHighlighting.Core.Tests/Example/expected.html
+++ b/src/Markdig.SyntaxHighlighting.Core.Tests/Example/expected.html
@@ -19,12 +19,12 @@
 </tbody>
 </table>
 <p>This is after the table</p>
-<div class="lang-csharp editor-colors"><div class="csharp"><pre>
-<span class="comment">// &#169;2015 Amido Limited (https://www.amido.com), Licensed under the terms of the Apache 2.0 Licence (http://www.apache.org/licenses/LICENSE-2.0)</span>
+<div class="lang-csharp editor-colors"><div style="color:#000000;background-color:#FFFFFF;"><pre>
+<span style="color:#008000;">// &#169;2015 Amido Limited (https://www.amido.com), Licensed under the terms of the Apache 2.0 Licence (http://www.apache.org/licenses/LICENSE-2.0)</span>
 
-<span class="keyword">namespace</span> Amido.VersionDashboard.Web.Domain {
-    <span class="keyword">public</span> <span class="keyword">interface</span> IConfigProvider {
-        <span class="keyword">string</span> GetSetting(<span class="keyword">string</span> appSetting);
+<span style="color:#0000FF;">namespace</span> Amido.VersionDashboard.Web.Domain {
+    <span style="color:#0000FF;">public</span> <span style="color:#0000FF;">interface</span> IConfigProvider {
+        <span style="color:#0000FF;">string</span> GetSetting(<span style="color:#0000FF;">string</span> appSetting);
     }
 }
 </pre></div>

--- a/src/Markdig.SyntaxHighlighting.Core.Tests/SyntaxHighlightingCodeBlockRendererTests.cs
+++ b/src/Markdig.SyntaxHighlighting.Core.Tests/SyntaxHighlightingCodeBlockRendererTests.cs
@@ -123,6 +123,32 @@ var desktop = Environment.SpecialFolder.DesktopDirectory;
             var markdownRenderer = new HtmlRenderer(new StringWriter(builder));
             var codeBlock = GetFencedCodeBlock();
             renderer.Write(markdownRenderer, codeBlock);
+            Assert.Contains("<span style=\"color:#0000FF;\">var</span>", builder.ToString());
+        }
+
+        [Fact]
+        public void WritesOutColouredCodeWithoutCss() {
+            var underlyingRendererMock = new Mock<CodeBlockRenderer>();
+            underlyingRendererMock
+                .Setup(x => x.Write(It.IsAny<HtmlRenderer>(), It.IsAny<CodeBlock>()));
+            var renderer = new SyntaxHighlightingCodeBlockRenderer(underlyingRendererMock.Object, false);
+            var builder = new StringBuilder();
+            var markdownRenderer = new HtmlRenderer(new StringWriter(builder));
+            var codeBlock = GetFencedCodeBlock();
+            renderer.Write(markdownRenderer, codeBlock);
+            Assert.Contains("<span style=\"color:#0000FF;\">var</span>", builder.ToString());
+        }
+
+        [Fact]
+        public void WritesOutColouredCodeWithCss() {
+            var underlyingRendererMock = new Mock<CodeBlockRenderer>();
+            underlyingRendererMock
+                .Setup(x => x.Write(It.IsAny<HtmlRenderer>(), It.IsAny<CodeBlock>()));
+            var renderer = new SyntaxHighlightingCodeBlockRenderer(underlyingRendererMock.Object, true);
+            var builder = new StringBuilder();
+            var markdownRenderer = new HtmlRenderer(new StringWriter(builder));
+            var codeBlock = GetFencedCodeBlock();
+            renderer.Write(markdownRenderer, codeBlock);
             Assert.Contains("<span class=\"keyword\">var</span>", builder.ToString());
         }
     }

--- a/src/Markdig.SyntaxHighlighting.Core/Markdig.SyntaxHighlighting.Core.csproj
+++ b/src/Markdig.SyntaxHighlighting.Core/Markdig.SyntaxHighlighting.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PackageId>Patmol.Markdig.SyntaxHighlighting.Core</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Cedric Evrard</Authors>
     <Company>Cedric Evrard</Company>
     <RepositoryUrl>https://github.com/Patmol/Markdig.SyntaxHighlighting.Core</RepositoryUrl>

--- a/src/Markdig.SyntaxHighlighting.Core/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/src/Markdig.SyntaxHighlighting.Core/SyntaxHighlightingCodeBlockRenderer.cs
@@ -12,9 +12,12 @@ namespace Markdig.SyntaxHighlighting.Core
     {
         private readonly CodeBlockRenderer _underlyingRenderer;
 
-        public SyntaxHighlightingCodeBlockRenderer(CodeBlockRenderer underlyingRenderer = null)
+        private bool _isUsingCssClasses;
+
+        public SyntaxHighlightingCodeBlockRenderer(CodeBlockRenderer underlyingRenderer = null, bool isUsingCssClasses = false)
         {
             _underlyingRenderer = underlyingRenderer ?? new CodeBlockRenderer();
+            _isUsingCssClasses = isUsingCssClasses;
         }
 
         protected override void Write(HtmlRenderer renderer, CodeBlock obj)
@@ -65,8 +68,16 @@ namespace Markdig.SyntaxHighlighting.Core
                 return code;
             }
 
-            var colourizer = new HtmlClassFormatter();
-            return colourizer.GetHtmlString(code, language);
+            if (_isUsingCssClasses) 
+            {
+                var colourizer = new HtmlClassFormatter();
+                return colourizer.GetHtmlString(code, language);
+            }
+            else
+            {
+                var colourizer = new HtmlFormatter();
+                return colourizer.GetHtmlString(code, language);
+            }
         }
 
         private static string GetCode(LeafBlock obj, out string firstLine)

--- a/src/Markdig.SyntaxHighlighting.Core/SyntaxHighlightingExtension.cs
+++ b/src/Markdig.SyntaxHighlighting.Core/SyntaxHighlightingExtension.cs
@@ -7,6 +7,13 @@ namespace Markdig.SyntaxHighlighting.Core
 {
     public class SyntaxHighlightingExtension : IMarkdownExtension
     {
+        private bool _isUsingCssClasses;
+
+        public SyntaxHighlightingExtension(bool isUsingCssClasses = false)
+        {
+            this._isUsingCssClasses = isUsingCssClasses;
+        }
+
         public void Setup(MarkdownPipelineBuilder pipeline) { }
 
         public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
@@ -29,7 +36,7 @@ namespace Markdig.SyntaxHighlighting.Core
             }
 
             htmlRenderer.ObjectRenderers.AddIfNotAlready(
-               new SyntaxHighlightingCodeBlockRenderer(originalCodeBlockRenderer));
+               new SyntaxHighlightingCodeBlockRenderer(originalCodeBlockRenderer, _isUsingCssClasses));
         }
     }
 }

--- a/src/Markdig.SyntaxHighlighting.Core/SyntaxHighlightingExtensions.cs
+++ b/src/Markdig.SyntaxHighlighting.Core/SyntaxHighlightingExtensions.cs
@@ -6,7 +6,13 @@ namespace Markdig.SyntaxHighlighting.Core
     {
         public static MarkdownPipelineBuilder UseSyntaxHighlighting(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.Add(new SyntaxHighlightingExtension());
+            pipeline.Extensions.Add(new SyntaxHighlightingExtension(false));
+            return pipeline;
+        }
+
+        public static MarkdownPipelineBuilder UseSyntaxHighlighting(this MarkdownPipelineBuilder pipeline, bool usingCssClasses)
+        {
+            pipeline.Extensions.Add(new SyntaxHighlightingExtension(usingCssClasses));
             return pipeline;
         }
     }


### PR DESCRIPTION
Closes #1 

Allow the user to choose between inline style or CSS classes for the syntax highlights